### PR TITLE
Added Typecast kwarg for post and update methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ coverage.xml
 .env
 .vscode
 .venv
+.python-version
 
 test.py


### PR DESCRIPTION
The following methods can now take the `typecast` kwarg which will allow new options to be added to Single and Multiple Select Fields.
- `await table.post_record(record, typecast=True)`
- `await table.post_records(records, typecast=True)`
- `await table.update_record(record, typecast=True)`
- `await table.update_records(records, typecast=True)`